### PR TITLE
Add automated API tests

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Claw Jobs API Tests
+ * 
+ * These tests verify all API routes are working correctly.
+ * Run with: npm test
+ */
+
+const BASE_URL = process.env.TEST_BASE_URL || 'https://claw-jobs.com';
+
+describe('Claw Jobs API', () => {
+  
+  // ==================== Health & Stats ====================
+  
+  describe('Health Check', () => {
+    it('GET /api/health should return 200', async () => {
+      const res = await fetch(`${BASE_URL}/api/health`);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.status).toBe('healthy');
+    });
+  });
+
+  describe('Stats', () => {
+    it('GET /api/stats should return platform stats', async () => {
+      const res = await fetch(`${BASE_URL}/api/stats`);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toHaveProperty('total_gigs');
+      expect(data).toHaveProperty('total_users');
+    });
+  });
+
+  // ==================== Agent Discovery ====================
+
+  describe('Agent Discovery', () => {
+    it('GET /api/skill should return skill.md content', async () => {
+      const res = await fetch(`${BASE_URL}/api/skill`);
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain('claw-jobs');
+    });
+
+    it('GET /skill.md should return skill.md content', async () => {
+      const res = await fetch(`${BASE_URL}/skill.md`);
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text).toContain('claw-jobs');
+    });
+
+    it('GET /.well-known/agent.json should return agent manifest', async () => {
+      const res = await fetch(`${BASE_URL}/.well-known/agent.json`);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toHaveProperty('name');
+      expect(data).toHaveProperty('capabilities');
+    });
+  });
+
+  // ==================== Gigs ====================
+
+  describe('Gigs API', () => {
+    it('GET /api/gigs should return gig list', async () => {
+      const res = await fetch(`${BASE_URL}/api/gigs`);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(Array.isArray(data)).toBe(true);
+    });
+
+    it('POST /api/gigs without auth should return 401', async () => {
+      const res = await fetch(`${BASE_URL}/api/gigs`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Test Gig',
+          description: 'Test description',
+          category: 'other',
+          budget_sats: 1000
+        })
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ==================== Auth ====================
+
+  describe('Auth API', () => {
+    it('GET /api/auth/me without auth should return null user', async () => {
+      const res = await fetch(`${BASE_URL}/api/auth/me`);
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.user).toBeNull();
+    });
+
+    it('POST /api/auth/signin with wrong creds should fail', async () => {
+      const res = await fetch(`${BASE_URL}/api/auth/signin`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'nonexistent@test.com',
+          password: 'wrongpassword123'
+        })
+      });
+      expect([400, 401]).toContain(res.status);
+    });
+  });
+
+  // ==================== Agent Registration ====================
+
+  describe('Agent Registration', () => {
+    it('POST /api/agents/register with missing fields should return 400', async () => {
+      const res = await fetch(`${BASE_URL}/api/agents/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      });
+      expect([400, 422]).toContain(res.status);
+    });
+  });
+
+  // ==================== Pages ====================
+
+  describe('Pages', () => {
+    it('GET / should return homepage', async () => {
+      const res = await fetch(BASE_URL);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('Claw Jobs');
+    });
+
+    it('GET /gigs should return gigs page', async () => {
+      const res = await fetch(`${BASE_URL}/gigs`);
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /gigs/new should return create gig page', async () => {
+      const res = await fetch(`${BASE_URL}/gigs/new`);
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /dashboard should return dashboard', async () => {
+      const res = await fetch(`${BASE_URL}/dashboard`);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ==================== Error Handling ====================
+
+  describe('Error Handling', () => {
+    it('GET /api/nonexistent should return 404', async () => {
+      const res = await fetch(`${BASE_URL}/api/nonexistent`);
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  testTimeout: 30000,
+  verbose: true,
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest",
+    "test:ci": "jest --ci"
   },
   "dependencies": {
     "next": "14.1.0",
@@ -29,6 +31,9 @@
     "postcss": "^8.4.33",
     "tailwindcss": "^3.4.1",
     "eslint": "^8.56.0",
-    "eslint-config-next": "14.1.0"
+    "eslint-config-next": "14.1.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "@types/jest": "^29.5.12"
   }
 }


### PR DESCRIPTION
## What
Adds a Jest test suite that verifies all API endpoints are working.

## Tests included
- ✅ Health check (`/api/health`)
- ✅ Stats (`/api/stats`)
- ✅ Agent discovery (`/api/skill`, `/skill.md`, `/.well-known/agent.json`)
- ✅ Gigs API (`GET /api/gigs`, `POST /api/gigs`)
- ✅ Auth API (`/api/auth/me`, `/api/auth/signin`)
- ✅ Agent registration (`/api/agents/register`)
- ✅ Pages (`/`, `/gigs`, `/gigs/new`, `/dashboard`)
- ✅ Error handling (404s)

## How to run
```bash
npm install
npm test
```

## GitHub Actions
Need to manually add `.github/workflows/test.yml` (token lacks workflow scope)

## Found issues
These pages return 404:
- `/my-gigs`
- `/signin`
- `/signup`