### PR TITLE
fix: Fix email confirmation redirect to localhost

### DIFF
--- a/app/api/auth/signin/route.ts
+++ b/app/api/auth/signin/route.ts
@@ -87,5 +87,5 @@ export async function POST(request: NextRequest) {
 
 // Redirect GET to the signin page
 export async function GET() {
-  return NextResponse.redirect(new URL('/auth/signin', process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'));
+  return NextResponse.redirect(new URL('/auth/signin', process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'));
 }

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -30,7 +30,8 @@ export async function POST(request: NextRequest) {
       data: {
         name,
         type: type || 'human'
-      }
+      },
+      emailRedirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/auth/callback`
     }
   });
 
@@ -70,5 +71,5 @@ export async function POST(request: NextRequest) {
 
 // Redirect GET to the signup page
 export async function GET() {
-  return NextResponse.redirect(new URL('/auth/signup', process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'));
+  return NextResponse.redirect(new URL('/auth/signup', process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'));
 }

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get('code');
+  const next = searchParams.get('next') ?? '/';
+
+  if (code) {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+    const supabase = createClient(supabaseUrl, supabaseKey);
+    
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    
+    if (!error) {
+      return NextResponse.redirect(new URL(next, origin));
+    }
+  }
+
+  // Return the user to an error page with instructions
+  return NextResponse.redirect(new URL('/auth/auth-code-error', origin));
+}


### PR DESCRIPTION
## Problem

Email confirmation links were redirecting to `http://localhost:3000` instead of the production URL. This prevented new users from completing registration.

## Root Causes

1. Missing `emailRedirectTo` option in Supabase signUp call
2. Used undefined `NEXT_PUBLIC_SITE_URL` env var instead of `NEXT_PUBLIC_APP_URL`

## Changes

- Add `emailRedirectTo` option to Supabase signUp with production callback URL
- Fix environment variable name in signin/signup redirect handlers
- Create `auth/callback` route to handle email confirmation exchanges
- Use `NEXT_PUBLIC_APP_URL` consistently (defined in `.env.example`)

## Files Changed

- `app/api/auth/signup/route.ts`: Add emailRedirectTo option
- `app/api/auth/signin/route.ts`: Fix env var name
- `app/auth/callback/route.ts`: New file for handling auth callbacks

## Testing

Deploy and test signup flow with production `NEXT_PUBLIC_APP_URL` set.

---

*Submitted by Gator (AI agent)*