### PR TITLE
feat: Add Accept/Reject buttons for gig applications

### DIFF
--- a/app/api/applications/[id]/route.ts
+++ b/app/api/applications/[id]/route.ts
@@ -1,0 +1,146 @@
+export const runtime = 'edge';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@/lib/supabase';
+
+// PATCH /api/applications/[id] - Update application status (accept/reject)
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  
+  // Check for API key auth (for agents)
+  const apiKey = request.headers.get('x-api-key') || request.headers.get('authorization')?.replace('Bearer ', '');
+  
+  // Check for session auth (for web UI)
+  const authHeader = request.headers.get('x-user-id');
+  
+  let userId: string | null = null;
+  
+  if (apiKey) {
+    const { data: user } = await supabase
+      .from('users')
+      .select('id')
+      .eq('api_key', apiKey)
+      .single();
+    if (user) userId = user.id;
+  } else if (authHeader) {
+    userId = authHeader;
+  }
+  
+  if (!userId) {
+    return NextResponse.json({
+      error: 'Authentication required',
+      hint: 'Provide x-api-key header or x-user-id header'
+    }, { status: 401 });
+  }
+
+  // Get the application with gig info
+  const { data: application, error: appError } = await supabase
+    .from('applications')
+    .select(`
+      id,
+      gig_id,
+      applicant_id,
+      status,
+      gig:gigs(id, poster_id, title, status)
+    `)
+    .eq('id', id)
+    .single();
+
+  if (appError || !application) {
+    return NextResponse.json({ error: 'Application not found' }, { status: 404 });
+  }
+
+  // Check if the user is the gig poster
+  const gig = application.gig as any;
+  if (gig.poster_id !== userId) {
+    return NextResponse.json({ 
+      error: 'Unauthorized',
+      message: 'Only the gig poster can accept/reject applications'
+    }, { status: 403 });
+  }
+
+  // Get the new status from request body
+  const body = await request.json();
+  const { status } = body;
+
+  if (!status || !['accepted', 'rejected'].includes(status)) {
+    return NextResponse.json({
+      error: 'Invalid status',
+      hint: 'Status must be "accepted" or "rejected"'
+    }, { status: 400 });
+  }
+
+  // If accepting, check if gig is still open
+  if (status === 'accepted' && gig.status !== 'open') {
+    return NextResponse.json({
+      error: 'Cannot accept application',
+      message: 'This gig is no longer open'
+    }, { status: 400 });
+  }
+
+  // Update the application status
+  const { error: updateError } = await supabase
+    .from('applications')
+    .update({ status })
+    .eq('id', id);
+
+  if (updateError) {
+    return NextResponse.json({ error: 'Failed to update application' }, { status: 500 });
+  }
+
+  // If accepted, update gig status and set selected worker
+  if (status === 'accepted') {
+    await supabase
+      .from('gigs')
+      .update({ 
+        status: 'in_progress',
+        selected_worker_id: application.applicant_id
+      })
+      .eq('id', application.gig_id);
+      
+    // Reject other pending applications for this gig
+    await supabase
+      .from('applications')
+      .update({ status: 'rejected' })
+      .eq('gig_id', application.gig_id)
+      .neq('id', id)
+      .eq('status', 'pending');
+  }
+
+  return NextResponse.json({
+    success: true,
+    message: `Application ${status}`,
+    application: { id, status }
+  });
+}
+
+// GET /api/applications/[id] - Get single application details
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  
+  const { data: application, error } = await supabase
+    .from('applications')
+    .select(`
+      id,
+      proposal_text,
+      proposed_price_sats,
+      status,
+      created_at,
+      applicant:users!applicant_id(id, name, type, reputation_score, total_gigs_completed),
+      gig:gigs(id, title, budget_sats, status, poster:users!poster_id(id, name))
+    `)
+    .eq('id', id)
+    .single();
+
+  if (error || !application) {
+    return NextResponse.json({ error: 'Application not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ application });
+}

--- a/app/my-gigs/page.tsx
+++ b/app/my-gigs/page.tsx
@@ -3,15 +3,42 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/lib/supabase';
 import GigCard from '@/components/GigCard';
-
 import Link from 'next/link';
+
+interface Application {
+  id: string;
+  proposal_text: string;
+  proposed_price_sats: number;
+  status: string;
+  created_at: string;
+  applicant: {
+    id: string;
+    name: string;
+    type: string;
+    reputation_score: number;
+    total_gigs_completed: number;
+  };
+}
+
+interface GigWithApplications {
+  id: string;
+  title: string;
+  description: string;
+  budget_sats: number;
+  status: string;
+  category: string;
+  created_at: string;
+  applications: Application[];
+}
 
 export default function MyGigsPage() {
   const [user, setUser] = useState<any>(null);
-  const [myGigs, setMyGigs] = useState<any[]>([]);
+  const [myGigs, setMyGigs] = useState<GigWithApplications[]>([]);
   const [myApplications, setMyApplications] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<'posted' | 'applied'>('posted');
+  const [expandedGig, setExpandedGig] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
 
   useEffect(() => {
     checkUser();
@@ -36,13 +63,24 @@ export default function MyGigsPage() {
   }
 
   async function fetchMyGigs(userId: string) {
-    const { data } = await supabase
+    // Fetch gigs with their applications
+    const { data: gigs } = await supabase
       .from('gigs')
-      .select('*')
+      .select(`
+        *,
+        applications(
+          id,
+          proposal_text,
+          proposed_price_sats,
+          status,
+          created_at,
+          applicant:users!applicant_id(id, name, type, reputation_score, total_gigs_completed)
+        )
+      `)
       .eq('poster_id', userId)
       .order('created_at', { ascending: false });
     
-    if (data) setMyGigs(data);
+    if (gigs) setMyGigs(gigs as GigWithApplications[]);
   }
 
   async function fetchMyApplications(userId: string) {
@@ -53,6 +91,43 @@ export default function MyGigsPage() {
       .order('created_at', { ascending: false });
     
     if (data) setMyApplications(data);
+  }
+
+  async function handleApplicationAction(applicationId: string, status: 'accepted' | 'rejected') {
+    if (!user) return;
+    setActionLoading(applicationId);
+
+    try {
+      const response = await fetch(`/api/applications/${applicationId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-user-id': user.id,
+        },
+        body: JSON.stringify({ status }),
+      });
+
+      const result = await response.json();
+      
+      if (response.ok) {
+        // Refresh the gigs to show updated status
+        fetchMyGigs(user.id);
+      } else {
+        alert(result.error || 'Failed to update application');
+      }
+    } catch (error) {
+      alert('Failed to update application');
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  function getPendingCount(gig: GigWithApplications): number {
+    return gig.applications?.filter(a => a.status === 'pending').length || 0;
+  }
+
+  function getTotalApplicationCount(gig: GigWithApplications): number {
+    return gig.applications?.length || 0;
   }
 
   if (loading) {
@@ -111,12 +186,12 @@ export default function MyGigsPage() {
           </button>
         </div>
 
-        {/* Posted Gigs */}
+        {/* Posted Gigs with Applications */}
         {activeTab === 'posted' && (
           <div>
             {myGigs.length === 0 ? (
               <div className="text-center py-12">
-                <p className="text-gray-400 mb-4">You haven't posted any gigs yet.</p>
+                <p className="text-gray-400 mb-4">You haven&apos;t posted any gigs yet.</p>
                 <Link
                   href="/gigs/new"
                   className="bg-yellow-500 hover:bg-yellow-400 text-black font-bold py-2 px-4 rounded-lg"
@@ -125,9 +200,144 @@ export default function MyGigsPage() {
                 </Link>
               </div>
             ) : (
-              <div className="grid gap-4">
+              <div className="space-y-4">
                 {myGigs.map((gig) => (
-                  <GigCard key={gig.id} gig={gig} />
+                  <div key={gig.id} className="bg-gray-800 rounded-lg overflow-hidden">
+                    {/* Gig Header */}
+                    <div 
+                      className="p-4 cursor-pointer hover:bg-gray-750"
+                      onClick={() => setExpandedGig(expandedGig === gig.id ? null : gig.id)}
+                    >
+                      <div className="flex justify-between items-start">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2">
+                            <h3 className="text-white font-medium">{gig.title}</h3>
+                            <span className={`px-2 py-0.5 rounded text-xs ${
+                              gig.status === 'open' ? 'bg-green-500/20 text-green-500' :
+                              gig.status === 'in_progress' ? 'bg-blue-500/20 text-blue-500' :
+                              gig.status === 'completed' ? 'bg-purple-500/20 text-purple-500' :
+                              'bg-gray-500/20 text-gray-500'
+                            }`}>
+                              {gig.status.replace('_', ' ')}
+                            </span>
+                          </div>
+                          <p className="text-gray-400 text-sm mt-1">
+                            {gig.budget_sats.toLocaleString()} sats • {gig.category}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-3">
+                          {getPendingCount(gig) > 0 && (
+                            <span className="bg-yellow-500 text-black text-xs font-bold px-2 py-1 rounded-full">
+                              {getPendingCount(gig)} pending
+                            </span>
+                          )}
+                          <span className="text-gray-400 text-sm">
+                            {getTotalApplicationCount(gig)} application{getTotalApplicationCount(gig) !== 1 ? 's' : ''}
+                          </span>
+                          <svg 
+                            className={`w-5 h-5 text-gray-400 transition-transform ${expandedGig === gig.id ? 'rotate-180' : ''}`}
+                            fill="none" 
+                            stroke="currentColor" 
+                            viewBox="0 0 24 24"
+                          >
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                          </svg>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Applications List (Expandable) */}
+                    {expandedGig === gig.id && (
+                      <div className="border-t border-gray-700 p-4">
+                        {!gig.applications || gig.applications.length === 0 ? (
+                          <p className="text-gray-500 text-sm text-center py-4">
+                            No applications yet
+                          </p>
+                        ) : (
+                          <div className="space-y-3">
+                            <h4 className="text-gray-300 font-medium text-sm mb-3">Applications</h4>
+                            {gig.applications.map((app) => (
+                              <div 
+                                key={app.id} 
+                                className={`bg-gray-900 rounded-lg p-4 ${
+                                  app.status === 'pending' ? 'border border-yellow-500/30' : ''
+                                }`}
+                              >
+                                <div className="flex justify-between items-start gap-4">
+                                  <div className="flex-1">
+                                    <div className="flex items-center gap-2">
+                                      <span className="text-white font-medium">
+                                        {app.applicant?.name || 'Unknown'}
+                                      </span>
+                                      <span className={`px-1.5 py-0.5 rounded text-xs ${
+                                        app.applicant?.type === 'agent' 
+                                          ? 'bg-purple-500/20 text-purple-400' 
+                                          : 'bg-blue-500/20 text-blue-400'
+                                      }`}>
+                                        {app.applicant?.type || 'user'}
+                                      </span>
+                                      {app.applicant?.reputation_score > 0 && (
+                                        <span className="text-yellow-500 text-xs">
+                                          ⭐ {app.applicant.reputation_score.toFixed(1)}
+                                        </span>
+                                      )}
+                                    </div>
+                                    <p className="text-gray-400 text-xs mt-1">
+                                      {app.applicant?.total_gigs_completed || 0} gigs completed
+                                    </p>
+                                    <p className="text-gray-300 text-sm mt-2">
+                                      {app.proposal_text}
+                                    </p>
+                                    <p className="text-yellow-500 text-sm mt-2 font-medium">
+                                      {app.proposed_price_sats.toLocaleString()} sats
+                                    </p>
+                                  </div>
+                                  <div className="flex flex-col items-end gap-2">
+                                    <span className={`px-2 py-1 rounded text-xs ${
+                                      app.status === 'pending' ? 'bg-yellow-500/20 text-yellow-500' :
+                                      app.status === 'accepted' ? 'bg-green-500/20 text-green-500' :
+                                      'bg-red-500/20 text-red-500'
+                                    }`}>
+                                      {app.status}
+                                    </span>
+                                    
+                                    {/* Accept/Reject Buttons - Only show for pending applications on open gigs */}
+                                    {app.status === 'pending' && gig.status === 'open' && (
+                                      <div className="flex gap-2 mt-2">
+                                        <button
+                                          onClick={(e) => {
+                                            e.stopPropagation();
+                                            handleApplicationAction(app.id, 'accepted');
+                                          }}
+                                          disabled={actionLoading === app.id}
+                                          className="bg-green-600 hover:bg-green-500 text-white text-xs font-medium px-3 py-1.5 rounded disabled:opacity-50"
+                                        >
+                                          {actionLoading === app.id ? '...' : '✓ Accept'}
+                                        </button>
+                                        <button
+                                          onClick={(e) => {
+                                            e.stopPropagation();
+                                            handleApplicationAction(app.id, 'rejected');
+                                          }}
+                                          disabled={actionLoading === app.id}
+                                          className="bg-red-600 hover:bg-red-500 text-white text-xs font-medium px-3 py-1.5 rounded disabled:opacity-50"
+                                        >
+                                          {actionLoading === app.id ? '...' : '✗ Reject'}
+                                        </button>
+                                      </div>
+                                    )}
+                                  </div>
+                                </div>
+                                <p className="text-gray-500 text-xs mt-2">
+                                  Applied {new Date(app.created_at).toLocaleDateString()}
+                                </p>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
                 ))}
               </div>
             )}
@@ -139,7 +349,7 @@ export default function MyGigsPage() {
           <div>
             {myApplications.length === 0 ? (
               <div className="text-center py-12">
-                <p className="text-gray-400 mb-4">You haven't applied to any gigs yet.</p>
+                <p className="text-gray-400 mb-4">You haven&apos;t applied to any gigs yet.</p>
                 <Link
                   href="/gigs"
                   className="bg-yellow-500 hover:bg-yellow-400 text-black font-bold py-2 px-4 rounded-lg"


### PR DESCRIPTION
## Changes

- Add `PATCH /api/applications/[id]` endpoint to accept/reject applications
- Update `/my-gigs` page to show applications for each posted gig
- Expandable application cards with applicant info
- Accept button: sets worker, marks gig in_progress, auto-rejects other pending
- Reject button: marks application as rejected
- Visual badges for pending applications count

## How it works

1. Poster clicks on their gig to expand
2. Sees all applications with applicant details (name, type, reputation, gigs completed)
3. Can Accept or Reject each pending application
4. Accepting auto-rejects other pending applications and starts the gig

Closes #23