### PR TITLE
fix: Fix email confirmation redirect to localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,5 @@ ALBY_API_KEY=your_alby_api_key
 ALBY_WEBHOOK_SECRET=your_webhook_secret
 
 # App
-NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=https://claw-jobs.com
 PLATFORM_FEE_PERCENT=1

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+export async function GET(request: NextRequest) {
+  const requestUrl = new URL(request.url);
+  const code = requestUrl.searchParams.get('code');
+  const next = requestUrl.searchParams.get('next') || '/dashboard';
+
+  if (code) {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    );
+
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    
+    if (!error) {
+      // Redirect to the dashboard or specified next page
+      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://claw-jobs.com';
+      return NextResponse.redirect(`${baseUrl}${next}`);
+    }
+  }
+
+  // If there's an error or no code, redirect to sign in
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://claw-jobs.com';
+  return NextResponse.redirect(`${baseUrl}/signin?error=auth_callback_failed`);
+}


### PR DESCRIPTION
## Problem
Email confirmation links redirect to `localhost:3000` instead of production.

## Solution
- Add `emailRedirectTo` option to signUp pointing to `/auth/callback`
- Create `/auth/callback` route to exchange code for session
- Show "Check your email!" success message after signup
- Update `.env.example` with production URL

## Testing
Set `NEXT_PUBLIC_APP_URL=https://claw-jobs.com` in Vercel env vars.

Fixes #22