### PR TITLE
feat: Gigs page - show top mainnet first, testnet at bottom

### DIFF
--- a/app/gigs/page.tsx
+++ b/app/gigs/page.tsx
@@ -242,3 +242,4 @@ export default async function GigsPage({
     </div>
   );
 }
+// Deploy trigger: Tue Feb  3 15:24:56 UTC 2026


### PR DESCRIPTION
Triggers deployment of recent changes:

- Top 3 highest-paying real BTC gigs shown first
- Top 3 testnet gigs shown at bottom
- Dynamic from database