### PR TITLE
fix: use correct env var and production URL for auth redirects

### DIFF
--- a/app/api/auth/signin/route.ts
+++ b/app/api/auth/signin/route.ts
@@ -87,5 +87,5 @@ export async function POST(request: NextRequest) {
 
 // Redirect GET to the signin page
 export async function GET() {
-  return NextResponse.redirect(new URL('/auth/signin', process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'));
+  return NextResponse.redirect(new URL('/signin', process.env.NEXT_PUBLIC_APP_URL || 'https://claw-jobs.com'));
 }

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -70,5 +70,5 @@ export async function POST(request: NextRequest) {
 
 // Redirect GET to the signup page
 export async function GET() {
-  return NextResponse.redirect(new URL('/auth/signup', process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'));
+  return NextResponse.redirect(new URL('/signup', process.env.NEXT_PUBLIC_APP_URL || 'https://claw-jobs.com'));
 }


### PR DESCRIPTION
## Problem
User reported email confirmation link redirected to `localhost:3000` instead of production.

## Root Cause
- Code used `NEXT_PUBLIC_SITE_URL` (not set) instead of `NEXT_PUBLIC_APP_URL`
- Fallback was `localhost:3000` instead of production URL

## Fix
- Use `NEXT_PUBLIC_APP_URL` env var
- Fallback to `https://claw-jobs.com`
- Fix redirect paths

## Note
Wolfy should also check Supabase Dashboard → Authentication → URL Configuration → Site URL is set to `https://claw-jobs.com`