### PR TITLE
fix: Address PR #52 test infrastructure review feedback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,11 +50,36 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       
-      - name: Run E2E tests against production
-        run: npm run test:e2e -- --project=api --project=chromium
+      # Start local Supabase for E2E tests
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase
+        run: |
+          supabase start
+          echo "NEXT_PUBLIC_SUPABASE_URL=$(supabase status -o env | grep API_URL | cut -d= -f2)" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$(supabase status -o env | grep ANON_KEY | cut -d= -f2)" >> $GITHUB_ENV
+          echo "SUPABASE_SERVICE_ROLE_KEY=$(supabase status -o env | grep SERVICE_ROLE_KEY | cut -d= -f2)" >> $GITHUB_ENV
+
+      - name: Run migrations
+        run: supabase db reset
+
+      # E2E tests run against localhost by default (via playwright.config.ts webServer)
+      # To test production, explicitly set TEST_BASE_URL=https://claw-jobs.com
+      - name: Run E2E tests
+        run: npm run test:e2e
         env:
-          TEST_BASE_URL: https://claw-jobs.com
+          # Defaults to http://localhost:3000 - do NOT target production in CI
+          # TEST_BASE_URL: http://localhost:3000
+          LIGHTNING_MODE: mock
+          LIGHTNING_NETWORK: testnet
+          ADMIN_SECRET: test-admin-secret-for-ci
           CI: true
+
+      - name: Stop Supabase
+        if: always()
+        run: supabase stop
       
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4

--- a/e2e/admin-flows.browser.spec.ts
+++ b/e2e/admin-flows.browser.spec.ts
@@ -5,8 +5,8 @@ test.describe('Admin Flows - Browser', () => {
     test('admin page requires authentication', async ({ page }) => {
       await page.goto('/admin');
       
-      // Should show login or access denied
-      await page.waitForTimeout(1000);
+      // Wait for page to settle (redirect or content load)
+      await page.waitForLoadState('networkidle');
       const content = await page.textContent('body');
       
       // Either redirected to signin or shows access denied
@@ -14,8 +14,7 @@ test.describe('Admin Flows - Browser', () => {
         page.url().includes('signin') ||
         content?.toLowerCase().includes('sign in') ||
         content?.toLowerCase().includes('unauthorized') ||
-        content?.toLowerCase().includes('access denied') ||
-        content?.toLowerCase().includes('admin');
+        content?.toLowerCase().includes('access denied');
       
       expect(isProtected).toBe(true);
     });
@@ -23,7 +22,8 @@ test.describe('Admin Flows - Browser', () => {
     test('admin moderation page is protected', async ({ page }) => {
       await page.goto('/admin/moderation');
       
-      await page.waitForTimeout(1000);
+      // Wait for page to settle
+      await page.waitForLoadState('networkidle');
       const currentUrl = page.url();
       const content = await page.textContent('body');
       
@@ -42,7 +42,8 @@ test.describe('Admin Flows - Browser', () => {
     test('admin users page is protected', async ({ page }) => {
       await page.goto('/admin/users');
       
-      await page.waitForTimeout(1000);
+      // Wait for page to settle
+      await page.waitForLoadState('networkidle');
       const currentUrl = page.url();
       const content = await page.textContent('body');
       

--- a/e2e/feedback-reporting.browser.spec.ts
+++ b/e2e/feedback-reporting.browser.spec.ts
@@ -70,8 +70,8 @@ test.describe('Feedback & Reporting - Browser', () => {
     test('404 page shows for invalid routes', async ({ page }) => {
       await page.goto('/this-page-does-not-exist-12345');
       
-      // Should show 404 or redirect
-      await page.waitForTimeout(1000);
+      // Wait for page to settle
+      await page.waitForLoadState('networkidle');
       const content = await page.textContent('body');
       expect(content?.toLowerCase()).toMatch(/not found|404|error|doesn't exist/i);
     });
@@ -79,7 +79,8 @@ test.describe('Feedback & Reporting - Browser', () => {
     test('offline page exists and contains offline content', async ({ page }) => {
       await page.goto('/offline');
       
-      await page.waitForTimeout(500);
+      // Wait for navigation to complete
+      await page.waitForLoadState('domcontentloaded');
       
       // Should navigate to offline page
       expect(page.url()).toContain('offline');

--- a/e2e/helpers/cleanup.ts
+++ b/e2e/helpers/cleanup.ts
@@ -1,6 +1,6 @@
 import { APIRequestContext } from '@playwright/test';
 
-const BASE = process.env.TEST_BASE_URL || 'https://claw-jobs.com';
+const BASE = process.env.TEST_BASE_URL || 'http://localhost:3000';
 
 // Track created test data for cleanup
 export interface TestData {
@@ -39,6 +39,11 @@ export function trackWebhook(id: string, owner_api_key: string) {
 /**
  * Clean up all tracked test data.
  * Call this in afterAll hook.
+ * 
+ * NOTE: Cleanup endpoints may not exist in production API.
+ * Test data (users named E2ETest_*, testnet gigs) may accumulate.
+ * This is acceptable for E2E testing - data is clearly marked as test data.
+ * Consider periodic manual cleanup or a dedicated test environment for heavy test runs.
  */
 export async function cleanupTestData(request: APIRequestContext) {
   const errors: string[] = [];

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -1,7 +1,7 @@
 import { APIRequestContext } from '@playwright/test';
 import { trackUser, trackGig } from './cleanup';
 
-const BASE = process.env.TEST_BASE_URL || 'https://claw-jobs.com';
+const BASE = process.env.TEST_BASE_URL || 'http://localhost:3000';
 
 export interface TestUser {
   id: string;

--- a/e2e/profile-flows.browser.spec.ts
+++ b/e2e/profile-flows.browser.spec.ts
@@ -6,7 +6,8 @@ test.describe('Profile & User Flows - Browser', () => {
       // Try to access a user profile (may not exist)
       await page.goto('/u/test-user');
       
-      await page.waitForTimeout(1000);
+      // Wait for page to settle
+      await page.waitForLoadState('networkidle');
       
       // Should show profile content or 404 page
       const content = await page.textContent('body');
@@ -30,7 +31,9 @@ test.describe('Profile & User Flows - Browser', () => {
     test('dashboard redirects when not authenticated', async ({ page }) => {
       await page.goto('/dashboard');
       
-      await page.waitForTimeout(2000);
+      // Wait for redirect to complete
+      await page.waitForLoadState('networkidle');
+      
       // Should redirect to signin or show access message
       const url = page.url();
       const content = await page.textContent('body');
@@ -46,7 +49,8 @@ test.describe('Profile & User Flows - Browser', () => {
     test('my-dashboard page requires authentication', async ({ page }) => {
       await page.goto('/my-dashboard');
       
-      await page.waitForTimeout(1000);
+      // Wait for page to settle
+      await page.waitForLoadState('networkidle');
       const currentUrl = page.url();
       const content = await page.textContent('body');
       
@@ -64,7 +68,8 @@ test.describe('Profile & User Flows - Browser', () => {
     test('my-gigs page requires authentication', async ({ page }) => {
       await page.goto('/my-gigs');
       
-      await page.waitForTimeout(1000);
+      // Wait for page to settle
+      await page.waitForLoadState('networkidle');
       const currentUrl = page.url();
       const content = await page.textContent('body');
       


### PR DESCRIPTION
Fixes critical issues identified in PR #52 review:

## Changes

### 1. **CRITICAL**: Changed TEST_BASE_URL default to localhost
- `e2e/helpers/fixtures.ts`: Changed from `https://claw-jobs.com` to `http://localhost:3000`
- `e2e/helpers/cleanup.ts`: Same fix
- E2E tests should never target production by default!

### 2. Removed misleading admin string check
- `e2e/admin-flows.browser.spec.ts`: Removed `content?.toLowerCase().includes("admin")` check
- This was always passing since "admin" appears in page headings

### 3. Documented cleanup endpoint limitations
- `e2e/helpers/cleanup.ts`: Added JSDoc note explaining cleanup endpoints may not exist and test data may accumulate

### 4. Replaced waitForTimeout with proper waits
- `admin-flows.browser.spec.ts`: Using `page.waitForLoadState("networkidle")`
- `profile-flows.browser.spec.ts`: Same
- `feedback-reporting.browser.spec.ts`: Same
- This follows Playwright best practices and makes tests more reliable

### 5. Updated CI workflow
- Now starts local Supabase for E2E tests
- Runs migrations before tests
- Added comments clarifying production testing requires explicit opt-in
- Removed hardcoded production URL

---

Blocks: #52